### PR TITLE
Use Locale.parse to restore zh_CN functionality

### DIFF
--- a/android2po/env.py
+++ b/android2po/env.py
@@ -53,7 +53,7 @@ class Language(object):
     def __init__(self, code, env=None):
         self.code = code
         self.env = env
-        self.locale = Locale(code) if code else None
+        self.locale = Locale.parse(code) if code else None
 
     def __unicode__(self):
         return unicode(self.code)

--- a/tests/test_language.py
+++ b/tests/test_language.py
@@ -1,0 +1,9 @@
+"""Test some edge cases for language functionality
+"""
+
+from android2po.env import Language
+
+
+def test_zh_CN():
+    Language('zh_CN')
+


### PR DESCRIPTION
Babel removed the guessing of scripts from the constructor and moved it
to a separate function we have to call.
